### PR TITLE
Show system notifications, based on a setting

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -14,6 +14,7 @@ export interface PomoSettings {
 	ribbonIcon: boolean;
 	emoji: boolean;
 	notificationSound: boolean;
+	useSystemNotification: boolean;
 	backgroundNoiseFile: string;
 	logging: boolean;
 	logFile: string;
@@ -34,6 +35,7 @@ export const DEFAULT_SETTINGS: PomoSettings = {
 	ribbonIcon: true,
 	emoji: true,
 	notificationSound: true,
+	useSystemNotification: false,
 	backgroundNoiseFile: "",
 	logging: false,
 	logFile: "Pomodoro Log.md",
@@ -149,6 +151,15 @@ export class PomoSettingTab extends PluginSettingTab {
 					this.plugin.saveSettings();
 				}));
 
+		new Setting(containerEl)
+			.setName("System notification")
+			.setDesc("Use system notifications at the end of each pomodoro and break")
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.useSystemNotification)
+				.onChange(value => {
+					this.plugin.settings.useSystemNotification = value;
+					this.plugin.saveSettings();
+				}));
 
 
 		/**************  Sound settings **************/

--- a/src/timer.ts
+++ b/src/timer.ts
@@ -356,7 +356,8 @@ function showSystemNotification(mode:Mode, useEmoji:boolean): void {
 	const Notification = (electron as any).remote.Notification;
 	const n = new Notification({
 		title: title,
-		body: text
+		body: text,
+		silent: true
 	});
 	n.on("click", () => {
 		n.close();


### PR DESCRIPTION
@kzhovn, this PR adds the option of system notification.
I like to have that and this is also requested in #38 

The implementation of the system notification the same as with the Obsidian Reminder plugin:
https://github.com/uphy/obsidian-reminder/blob/master/src/ui/reminder.ts#L24

Which is based on the Electron documentation:
https://www.electronjs.org/docs/latest/tutorial/notifications   
https://www.electronjs.org/docs/latest/api/notification   